### PR TITLE
Fix prefix issue in TexturePack toggle_textures

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,12 @@ The `TexturePack` will use the first object in your first `AltTexture` listed in
 
 You can also change the text of objects you are not retexturing by setting the following value:
 - `localization`, set to `true` when using a localization file,  alternatively a table of alternate localizations for your new textures:
+
+Textures can be set to be disabled by default by adding them to an additional table listing `AltTexture` keys:
+```lua
+{
+  textures = {'mod_prefix_alttexturekey', 'mod_prefix_disabledalttexturekey'}
+  toggle_textures = {'mod_prefix_disabledalttexturekey'}
+  -- Textures listed in toggle_textures must be included in textures as well
+}
+```

--- a/api/AltTexture.lua
+++ b/api/AltTexture.lua
@@ -194,13 +194,20 @@ TexturePack = SMODS.GameObject:extend {
             new_textures[#new_textures + 1] = temp.key
         end
         self.textures = new_textures
+        local new_toggle_textures = {}
+        for _, key in ipairs(self.toggle_textures or {}) do
+            local temp = {key = key}
+            SMODS.modify_key(temp, 'alt_tex', true)
+            new_toggle_textures[#new_toggle_textures + 1] = temp.key
+        end
+        self.toggle_textures = new_toggle_textures
         if not Malverk.config.texture_configs then Malverk.config.texture_configs = {} end
         if not Malverk.config.texture_configs[self.key] then
             Malverk.config.texture_configs[self.key] = {}
             for _, key in ipairs(self.textures) do
                 Malverk.config.texture_configs[self.key][key] = true
             end
-            for _, key in ipairs(self.toggle_textures or {}) do
+            for _, key in ipairs(self.toggle_textures) do
                 Malverk.config.texture_configs[self.key][key] = false
             end
         else
@@ -209,7 +216,7 @@ TexturePack = SMODS.GameObject:extend {
                     Malverk.config.texture_configs[self.key][key] = true
                 end
             end
-            for _, key in ipairs(self.toggle_textures or {}) do
+            for _, key in ipairs(self.toggle_textures) do
                 if type(Malverk.config.texture_configs[self.key][key]) ~= 'boolean' then
                     Malverk.config.texture_configs[self.key][key] = false
                 end


### PR DESCRIPTION
Fixes #4 by adding prefix to `toggle_textures` similarly to how it's done for `textures`
Adds documentation to `toggle_textures` argument in `TexturePack`
