### PR TITLE
fix attempt to index nil field when a card is highlighted before it's fully rendered

### DIFF
--- a/utils/ui.lua
+++ b/utils/ui.lua
@@ -294,7 +294,7 @@ function Card:highlight(highlighted)
         return
     end
     card_highlight(self, highlighted)
-    if highlighted and self.area.config.texture_pack then
+    if highlighted and self.area and self.area.config.texture_pack then
         self.children.use_button = UIBox{
             definition = create_texture_pack_buttons(self, self.texture_selected), 
             config = {align = 'cm', offset = {x=0, y=0.4}, parent = self}


### PR DESCRIPTION
this fixes an interaction with my keyboard controls mod <https://github.com/janw4ld/balatro-typist-mod> that crashes the game when a player is trying to select cards before they're fully initialised and rendered (they've just rerolled the shop and immediately pressed a card button). the game's implementation of `Card:highlight` handles this gracefully and does nothing but Malverk attempts to index fields that don't exist on the card leading to a `[SMODS malverk "utils/ui.lua"]:297: attempt to index field 'area' (a nil value)` crash.