### PR TITLE
Fix inability to include Soul card with other cards in same spritesheet

### DIFF
--- a/malverk.lua
+++ b/malverk.lua
@@ -111,7 +111,7 @@ function Malverk.update_atlas(atlas_type)
                                         G.shared_stickers[center] = Sprite(0, 0, G.CARD_W, G.CARD_H, G.ASSET_ATLAS[texture.atlas and texture.atlas.key or 'stickers'], texture.columns and not texture.original_sheet and {x = (i-1) % texture.columns, y = math.floor((i-1)/texture.columns)} or G.default_stickers[center].sprite_pos)
                                     end
                                 end
-                                if texture.soul_keys and table.contains(texture.soul_keys, center) then
+                                if texture.soul_keys and table.contains(texture.soul_keys, center) and center ~= 'c_soul' then
                                     soul_count = soul_count + 1
                                     G[game_table][center].soul_pos = {x = (i+soul_count-1) % texture.columns, y = math.floor((i+soul_count-1)/texture.columns)}
                                 elseif G[game_table][center].soul_pos and center ~= 'c_soul' then


### PR DESCRIPTION
### The Issue
This merge fixes an issue with using the Soul card in a larger spritesheet.
When including the Soul card in an `AltTexture`'s `soul_keys` table, the textures after it get messed up and appear out-of-order. The Soul card ends up applying 3 layers: the base card, the adjacent overlay image as the Default Soul Sprite, and then the next card as another overlay image.

For example:
```lua
AltTexture({
    key = "soul_and_bh",
    set = "Spectral",
    path = "soul_and_bh.png",
    keys = { "c_soul", "c_black_hole" },
    soul_keys = { "c_soul", "c_black_hole" }, -- Add extra overlay texture to Black Hole
    loc_txt = { name = "Soul & Black Hole" },
})
--Another texture with blank Spectral cards is included in the screenshots
```
<img width="284" alt="soul_and_bh" src="https://github.com/user-attachments/assets/d958d51e-8b7b-455f-9f6c-5cf6ebc467ba" />

Without the fix:
<img width="284" alt="soul_and_bh preview" src="https://github.com/user-attachments/assets/450b5f8e-8f26-462c-966a-177e5e0c7810" />
With the fix:
<img width="284" height="771" alt="spectrals_and_soul_bh_end preview fixed" src="https://github.com/user-attachments/assets/0844f633-c05c-4021-beda-b7e92f0e9d59" />

### The Fix
In `Malverk.update_atlas`, in the texture loop, if `"c_soul"` is in `soul_keys`, then the `soul_count` variable gets incremented twice, once on line 101 and again on line 115. The fix copies the condition from the next elseif that was missing in the previous if.

### Testing
I created this test mod: 
[balatro-testmalverk-soul.zip](https://github.com/user-attachments/files/23832104/balatro-testmalverk-soul.zip)

I also tested it with these other mods:
* https://github.com/Eremel/Aure-Spectral
* https://github.com/Eremel/HD-Balatro
* https://github.com/OppositeWolf770/SoulEverything