### PR TITLE
Fix booster pack localization defaults

### DIFF
--- a/malverk.lua
+++ b/malverk.lua
@@ -54,10 +54,18 @@ function Malverk.set_defaults()
                         G[game_table][center].set_card_type_badge = G[game_table][center].default_card_type_badge
                     end
 
-                    G[game_table][center].default_loc_txt = G[game_table][center].default_loc_txt or copy_table(G.localization.descriptions[AltTextures_Utils.loc_table[texture.set] or texture.set][center .. (texture.set == Seal and '_seal' or '')])
-                    local default_loc = G[game_table][center].default_loc_txt
-                    SMODS.process_loc_text(G.localization.descriptions[AltTextures_Utils.loc_table[texture.set] or texture.set][center .. (texture.set == Seal and '_seal' or '')], 'name', default_loc, 'name')
-                    SMODS.process_loc_text(G.localization.descriptions[AltTextures_Utils.loc_table[texture.set] or texture.set][center .. (texture.set == Seal and '_seal' or '')], 'text', default_loc, 'text')
+                    if texture.set == 'Booster' then
+                        local temp_center = center:sub(1, -3)
+                        G[game_table][center].default_loc_txt = G[game_table][center].default_loc_txt or copy_table(G.localization.descriptions.Other[temp_center])
+                        local default_loc = G[game_table][center].default_loc_txt
+                        SMODS.process_loc_text(G.localization.descriptions.Other[temp_center], 'name', default_loc, 'name')
+                        SMODS.process_loc_text(G.localization.descriptions.Other[temp_center], 'text', default_loc, 'text')
+                    else
+                        G[game_table][center].default_loc_txt = G[game_table][center].default_loc_txt or copy_table(G.localization.descriptions[AltTextures_Utils.loc_table[texture.set] or texture.set][center .. (texture.set == Seal and '_seal' or '')])
+                        local default_loc = G[game_table][center].default_loc_txt
+                        SMODS.process_loc_text(G.localization.descriptions[AltTextures_Utils.loc_table[texture.set] or texture.set][center .. (texture.set == Seal and '_seal' or '')], 'name', default_loc, 'name')
+                        SMODS.process_loc_text(G.localization.descriptions[AltTextures_Utils.loc_table[texture.set] or texture.set][center .. (texture.set == Seal and '_seal' or '')], 'text', default_loc, 'text')
+                    end
                     
                 end
             end


### PR DESCRIPTION
### The Issue
When having an `AltTexture` that changes the localization text of a Booster pack, enabling then disabling the texture does **not** revert the text back to normal.

Example:
```lua
AltTexture({
    key = "boosters",
    set = "Booster",
    path = "boosters.png",
    keys = {
        "p_arcana_normal_1", "p_arcana_normal_2", "p_arcana_normal_3", "p_arcana_normal_4",
    },
    loc_txt = { name = "Boosters" },
    localization = {
        p_arcana_normal = {
            name = "TEST Arcana",
            text = { "TEST TEXT Arcana" },
        },
    },
})
```

The issue can be reproduced by:
* Using this test mod:  [balatro-testmalverk-booster.zip](https://github.com/user-attachments/files/23832184/balatro-testmalverk-booster.zip)
* Applying the texture
* Looking at the Arcana Packs in the collection screen
* Removing the texture
* Looking at the Arcana Packs again and seeing that the name is still the modified one

### The Fix
The issue is caused by the default localization text not being saved properly for Boosters in `Malverk.set_defaults`. The fix is done by mirrorring the logic for Booster pack localization in the other functions, like at line 132.